### PR TITLE
handle the $HOME (and similar) env var not being set

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,14 @@
 'use strict';
-module.exports = process.platform === 'win32' ? (process.env.USERPROFILE || process.env.HOMEDRIVE + process.env.HOMEPATH) : process.env.HOME;
+var env = process.env;
+var home = env.HOME;
+var user = env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+
+if (process.platform === 'win32') {
+	module.exports = env.USERPROFILE || env.HOMEDRIVE + env.HOMEPATH || home;
+} else if (process.platform === 'darwin') {
+	module.exports = home || (user ? '/Users/' + user : null);
+} else if (process.platform === 'linux') {
+	module.exports = home || (user ? (process.getuid() === 0 ? '/root' : '/home/' + user) : null);
+} else {
+	module.exports = home;
+}


### PR DESCRIPTION
some environments like Jenkins doesn't always have a $HOME env var

@passy @sboudrias @kevva @stephenplusplus could use your opinion here.
